### PR TITLE
Support pre-existing artwork from Mopidy back-ends

### DIFF
--- a/mopidy_pidi/__init__.py
+++ b/mopidy_pidi/__init__.py
@@ -2,10 +2,10 @@ from __future__ import unicode_literals
 
 import logging
 import os
+
 from pkg_resources import iter_entry_points
 
 from mopidy import config, ext
-
 
 __version__ = "0.1.0"
 

--- a/mopidy_pidi/brainz.py
+++ b/mopidy_pidi/brainz.py
@@ -1,12 +1,13 @@
 """
 Musicbrainz related functions.
 """
-import time
-import musicbrainzngs as mus
-import os
-from threading import Thread
 import base64
-    
+import os
+import time
+from threading import Thread
+
+import musicbrainzngs as mus
+
 from .__init__ import __version__
 
 
@@ -28,16 +29,12 @@ class Brainz:
                 return callback(self._default_filename)
             return self._default_filename
 
-        file_name = "{artist}_{album}".format(
+        file_name = self.get_cache_file_name("{artist}_{album}".format(
             artist=artist,
             album=album
-        )
+        ))
 
-        file_name = "{}.jpg".format(base64.b64encode(file_name))
-
-        file_name = os.path.join(self._cache_dir, file_name)
-
-        if os.path.exists(file_name):
+        if os.path.isfile(file_name):
             # If a cached file already exists, use it!
             if callback is not None:
                 return callback(file_name)
@@ -108,6 +105,11 @@ class Brainz:
             print("error: Couldn't find album art for",
                   "{artist} - {album}".format(artist=artist, album=album))
             return None
+
+    def get_cache_file_name(self, file_name):
+        file_name = "{}.jpg".format(base64.b64encode(file_name))
+
+        return os.path.join(self._cache_dir, file_name)
 
     def get_default_album_art(self):
         """Return binary version of default album art."""

--- a/mopidy_pidi/brainz.py
+++ b/mopidy_pidi/brainz.py
@@ -89,7 +89,7 @@ class Brainz:
                                        release=album,
                                        limit=1)
             release_id = data["release-list"][0]["release-group"]["id"]
-            print("mopidy-pidi: musicbrainz sing release-id: {}".format(data['release-list'][0]['id']))
+            print("mopidy-pidi: musicbrainz using release-id: {}".format(data['release-list'][0]['id']))
 
             return mus.get_release_group_image_front(release_id, size=size)
 
@@ -102,8 +102,7 @@ class Brainz:
             self.request_album_art(song, artist, album, size=size, retries=retries - 1)
 
         except mus.ResponseError:
-            print("mopidy-pidi: musicbrainz couldn't find album art for",
-                  "{artist} - {album}".format(artist=artist, album=album))
+            print("mopidy-pidi: musicbrainz couldn't find album art for {artist} - {album}".format(artist=artist, album=album))
             return None
 
     def get_cache_file_name(self, file_name):

--- a/mopidy_pidi/brainz.py
+++ b/mopidy_pidi/brainz.py
@@ -89,7 +89,7 @@ class Brainz:
                                        release=album,
                                        limit=1)
             release_id = data["release-list"][0]["release-group"]["id"]
-            print("album: Using release-id: {}".format(data['release-list'][0]['id']))
+            print("mopidy-pidi: musicbrainz sing release-id: {}".format(data['release-list'][0]['id']))
 
             return mus.get_release_group_image_front(release_id, size=size)
 
@@ -97,12 +97,12 @@ class Brainz:
             if retries == 0:
                 # raise mus.NetworkError("Failure connecting to MusicBrainz.org")
                 return None
-            print("warning: Retrying download. {retries} retries left!".format(retries=retries))
+            print("mopidy-pidi: musicbrainz retrying download. {retries} retries left!".format(retries=retries))
             time.sleep(retry_delay)
             self.request_album_art(song, artist, album, size=size, retries=retries - 1)
 
         except mus.ResponseError:
-            print("error: Couldn't find album art for",
+            print("mopidy-pidi: musicbrainz couldn't find album art for",
                   "{artist} - {album}".format(artist=artist, album=album))
             return None
 

--- a/mopidy_pidi/frontend.py
+++ b/mopidy_pidi/frontend.py
@@ -122,9 +122,12 @@ class PiDiFrontend(pykka.ThreadingActor, core.CoreListener):
         track_images = self.core.library.get_images([track.uri]).get()
         if track.uri in track_images:
             track_images = track_images[track.uri]
-            for image in track_images:
-                if image.height == 300 and image.width == 300:
-                    art = image.uri
+            if len(track_images) == 1:
+                art = track_images[0].uri
+            else:
+                for image in track_images:
+                    if image.height >= 240 and image.width >= 240:
+                        art = image.uri
 
         self.display.update_album_art(art=art)
 

--- a/mopidy_pidi/frontend.py
+++ b/mopidy_pidi/frontend.py
@@ -189,26 +189,27 @@ class PiDi():
     def update_album_art(self, art=None):
         _album = self.title if self.album is None or self.album == '' else self.album
 
-        if os.path.isfile(art):
-            # Art is already a locally cached file we can use
-            self._handle_album_art(art)
-            return
-
-        elif art.startswith("http://") or art.startswith("https://"):
-            file_name = self._brainz.get_cache_file_name(art)
-
-            if os.path.isfile(file_name):
-                # If a cached file already exists, use it!
-                self._handle_album_art(file_name)
+        if art is not None:
+            if os.path.isfile(art):
+                # Art is already a locally cached file we can use
+                self._handle_album_art(art)
                 return
 
-            else:
-                # Otherwise, request the URL and save it!
-                response = requests.get(art)
-                if response.status_code == 200:
-                    self._brainz.save_album_art(response.content, file_name)
+            elif art.startswith("http://") or art.startswith("https://"):
+                file_name = self._brainz.get_cache_file_name(art)
+
+                if os.path.isfile(file_name):
+                    # If a cached file already exists, use it!
                     self._handle_album_art(file_name)
                     return
+
+                else:
+                    # Otherwise, request the URL and save it!
+                    response = requests.get(art)
+                    if response.status_code == 200:
+                        self._brainz.save_album_art(response.content, file_name)
+                        self._handle_album_art(file_name)
+                        return
 
         art = self._brainz.get_album_art(self.artist, _album, self._handle_album_art)
 


### PR DESCRIPTION
Currently only tested on Spotify, this feature update defers to Mopidy's `core.library.get_images()` function in order to grab the album art for the currently playing track. This is considerably quicker than a MusicBrainz lookup, and will match the album art on the display to that in other front-ends such as Iris.


### Tested in:

* mopidy-soundcloud ✔️ 
* mopidy-podcast with mopidy-podcast-itunes ✔️ 
* mopidy-internetarchive ✔️ 