### PR TITLE
Show HTTP address on launch

### DIFF
--- a/mopidy_pidi/frontend.py
+++ b/mopidy_pidi/frontend.py
@@ -58,6 +58,7 @@ class PiDiFrontend(pykka.ThreadingActor, core.CoreListener):
                     self.display.update(
                         title="Visit http://{hostname}:{port} to select content.".format(hostname=hostname, port=port)
                     )
+                    self.display.update_album_art(art='')
 
     def on_stop(self):
         self.display.stop()

--- a/mopidy_pidi/frontend.py
+++ b/mopidy_pidi/frontend.py
@@ -8,7 +8,6 @@ import time
 import netifaces
 import pykka
 from mopidy import core
-from pidi_display_st7789 import DisplayST7789
 
 from . import Extension
 from .brainz import Brainz

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,8 @@ setup(
         "setuptools",
         "Mopidy >= 2.2",
         "Pykka >= 2.0",
-        "musicbrainzngs >= 0.6"
+        "musicbrainzngs >= 0.6",
+        "netifaces"
     ],
     entry_points={
         "mopidy.ext": [


### PR DESCRIPTION
Will check for an enabled `http` plugin on launch and display the configured hostname:port in the form "Visit http://hostname:port to select content."

If the hostname is configured to "0.0.0.0" (bind all) then it will automatically call out to `hostname -I` and split out the first IP address for display.