### PR TITLE
Update frontend.py to adjust how play/pause images are shown on the P…

### DIFF
--- a/mopidy_pidi/frontend.py
+++ b/mopidy_pidi/frontend.py
@@ -96,19 +96,19 @@ class PiDiFrontend(pykka.ThreadingActor, core.CoreListener):
 
     def track_playback_ended(self, tl_track, time_position):
         self.update_elapsed(time_position)
-        self.display.update(state="pause")
+        self.display.update(state="play")
 
     def track_playback_paused(self, tl_track, time_position):
         self.update_elapsed(time_position)
-        self.display.update(state="pause")
+        self.display.update(state="play")
 
     def track_playback_resumed(self, tl_track, time_position):
         self.update_elapsed(time_position)
-        self.display.update(state="play")
+        self.display.update(state="pause")
 
     def track_playback_started(self, tl_track):
         self.update_track(tl_track.track, 0)
-        self.display.update(state="play")
+        self.display.update(state="pause")
 
     def update_elapsed(self, time_position):
         self.display.update(elapsed=float(time_position))


### PR DESCRIPTION
…irate Audio display

Prior to this change, the image displayed on the screen next to the "A" button seemed opposite of what one would expect. When music is playing it showed the ">" (play) image and when the music is paused it showed the "||" (pause) image. One would expect that image to show the user what they'd like the system to do when they PRESS the button (NOT what the system is currently doing). This change makes it consistent with how other media players behave in this regard.