### PR TITLE
Update frontend.py

### DIFF
--- a/mopidy_pidi/frontend.py
+++ b/mopidy_pidi/frontend.py
@@ -92,8 +92,8 @@ class PiDiFrontend(pykka.ThreadingActor, core.CoreListener):
         self.update_elapsed(time_position)
 
     def stream_title_changed(self, title):
-        self.display.update(title=title)
-
+#        self.display.update(title=title)
+        pass
     def track_playback_ended(self, tl_track, time_position):
         self.update_elapsed(time_position)
         self.display.update(state="pause")


### PR DESCRIPTION
Changed function stream_title_changed to pass. This function is intended to update the title variable when it sees a change, but it pulls stale data (at least when using the Jellyfin backend), which causes the displayed title to revert back to the previous track's title. This is a redundant function anyway due to the display update loop, so I have simply removed the variable update line and set the function to simply pass.